### PR TITLE
Exit non-zero if arguments were not supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ if (!argv.alias || !argv.name) {
 -a  --alias       [required]
   (mysweetapp.com)`)
 
-	return
+	process.exit(1)
 }
 
 const now = new Now(argv.token)


### PR DESCRIPTION
Exit non-zero if arguments were not supplied.

If this was in a script, and too few arguments were given, I'd expect a non-0 exit code.